### PR TITLE
make sure no windows stuff gets compiled on linux

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -3,7 +3,12 @@ use std::fs::{self, File, OpenOptions};
 use std::{io, ptr};
 use std::os::windows::prelude::*;
 use std::path::{Path, PathBuf};
-use super::*;
+
+use winapi::*;
+use kernel::*;
+
+pub const ERROR_INSUFFICIENT_BUFFER: DWORD = 122;
+pub const VOLUME_NAME_DOS: DWORD = 0x0;
 
 struct RmdirContext<'a> {
     base_dir: &'a Path,
@@ -175,7 +180,7 @@ fn rename(file: &File, new: &Path, replace: bool) -> io::Result<()> {
 
 fn get_path(f: &File) -> io::Result<PathBuf> {
 
-    super::fill_utf16_buf(|buf, sz| unsafe {
+    fill_utf16_buf(|buf, sz| unsafe {
         GetFinalPathNameByHandleW(f.as_raw_handle(), buf, sz, VOLUME_NAME_DOS)
     }, |buf| {
         PathBuf::from(OsString::from_wide(buf))
@@ -197,5 +202,52 @@ fn remove_dir_all_recursive(path: &Path, ctx: &mut RmdirContext)
     }
     ctx.readonly = dir_readonly;
     remove_item(path, ctx)
+}
+
+fn fill_utf16_buf<F1, F2, T>(mut f1: F1, f2: F2) -> io::Result<T>
+    where F1: FnMut(*mut u16, DWORD) -> DWORD,
+          F2: FnOnce(&[u16]) -> T
+{
+    // Start off with a stack buf but then spill over to the heap if we end up
+    // needing more space.
+    let mut stack_buf = [0u16; 512];
+    let mut heap_buf = Vec::new();
+    unsafe {
+        let mut n = stack_buf.len();
+
+        loop {
+            let buf = if n <= stack_buf.len() {
+                &mut stack_buf[..]
+            } else {
+                let extra = n - heap_buf.len();
+                heap_buf.reserve(extra);
+                heap_buf.set_len(n);
+                &mut heap_buf[..]
+            };
+
+            // This function is typically called on windows API functions which
+            // will return the correct length of the string, but these functions
+            // also return the `0` on error. In some cases, however, the
+            // returned "correct length" may actually be 0!
+            //
+            // To handle this case we call `SetLastError` to reset it to 0 and
+            // then check it again if we get the "0 error value". If the "last
+            // error" is still 0 then we interpret it as a 0 length buffer and
+            // not an actual error.
+            SetLastError(0);
+            let k = match f1(buf.as_mut_ptr(), n as DWORD) {
+                0 if GetLastError() == 0 => 0,
+                0 => return Err(io::Error::last_os_error()),
+                n => n,
+            } as usize;
+            if k == n && GetLastError() == ERROR_INSUFFICIENT_BUFFER {
+                n *= 2;
+            } else if k >= n {
+                n = k;
+            } else {
+                return Ok(f2(&buf[..k]))
+            }
+        }
+    }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,65 +1,12 @@
 extern crate winapi;
 extern crate kernel32 as kernel;
 
+#[cfg(windows)]
 mod fs;
-
-use std::io;
-use winapi::*;
-use kernel::*;
-
-pub const ERROR_INSUFFICIENT_BUFFER: DWORD = 122;
-pub const VOLUME_NAME_DOS: DWORD = 0x0;
 
 #[cfg(windows)]
 pub use self::fs::remove_dir_all;
 
 #[cfg(not(windows))]
 pub use std::fs::remove_dir_all;
-
-fn fill_utf16_buf<F1, F2, T>(mut f1: F1, f2: F2) -> io::Result<T>
-    where F1: FnMut(*mut u16, DWORD) -> DWORD,
-          F2: FnOnce(&[u16]) -> T
-{
-    // Start off with a stack buf but then spill over to the heap if we end up
-    // needing more space.
-    let mut stack_buf = [0u16; 512];
-    let mut heap_buf = Vec::new();
-    unsafe {
-        let mut n = stack_buf.len();
-
-        loop {
-            let buf = if n <= stack_buf.len() {
-                &mut stack_buf[..]
-            } else {
-                let extra = n - heap_buf.len();
-                heap_buf.reserve(extra);
-                heap_buf.set_len(n);
-                &mut heap_buf[..]
-            };
-
-            // This function is typically called on windows API functions which
-            // will return the correct length of the string, but these functions
-            // also return the `0` on error. In some cases, however, the
-            // returned "correct length" may actually be 0!
-            //
-            // To handle this case we call `SetLastError` to reset it to 0 and
-            // then check it again if we get the "0 error value". If the "last
-            // error" is still 0 then we interpret it as a 0 length buffer and
-            // not an actual error.
-            SetLastError(0);
-            let k = match f1(buf.as_mut_ptr(), n as DWORD) {
-                0 if GetLastError() == 0 => 0,
-                0 => return Err(io::Error::last_os_error()),
-                n => n,
-            } as usize;
-            if k == n && GetLastError() == ERROR_INSUFFICIENT_BUFFER {
-                n *= 2;
-            } else if k >= n {
-                n = k;
-            } else {
-                return Ok(f2(&buf[..k]))
-            }
-        }
-    }
-}
 


### PR DESCRIPTION
This broke things on *nix systems because it still tried to use windows-specific stuff (DWORD, etc) on linux. I moved all windows-specific into `src/fs.rs` and made `mod fs;` dependent on `#[cfg(windows)]`.