### PR TITLE
Remove duplicate const

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use winapi::*;
 use kernel::*;
 
-pub const ERROR_INSUFFICIENT_BUFFER: DWORD = 122;
 pub const VOLUME_NAME_DOS: DWORD = 0x0;
 
 struct RmdirContext<'a> {


### PR DESCRIPTION
Removes the `ERROR_INSUFFICIENT_BUFFER` const that's shadowing an equivalent import from `winapi`. This just makes the crate compile on `rustc 1.13.0`.

cc: @Aaronepower