### PR TITLE
Fix readonly deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+- Fixed deletion of readonly items
+
 # 0.5.0
 
 - Upgraded to winapi 0.3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # remove_dir_all
 
-[**documentation**](https://docs.rs/remove_dir_all/)
+[![Latest Version](https://img.shields.io/crates/v/remove_dir_all.svg)](https://crates.io/crates/remove_dir_all)
+[![Docs](https://docs.rs/remove_dir_all/badge.svg)](https://docs.rs/remove_dir_all)
+[![License](https://img.shields.io/github/license/Aaronepower/remove_dir_all.svg)](https://github.com/Aaronepower/remove_dir_all)
+
+## Description
 
 A reliable implementation of `remove_dir_all` for Windows. For Unix systems
 re-exports `std::fs::remove_dir_all`.

--- a/tests/windows.rs
+++ b/tests/windows.rs
@@ -1,0 +1,99 @@
+#![cfg(windows)]
+
+extern crate remove_dir_all;
+
+use remove_dir_all::remove_dir_all;
+use std::fs::{self, File};
+
+macro_rules! assert_not_found {
+    ($path:expr) => {{
+        match fs::metadata($path) {
+            Ok(_) => panic!("did not expect to retrieve metadata for {}", $path),
+            Err(ref err) if err.kind() != ::std::io::ErrorKind::NotFound => {
+                panic!("expected path {} to be NotFound, was {:?}", $path, err)
+            },
+            _ => {}
+        }
+    }}
+}
+
+#[test]
+fn removes_empty() {
+    fs::create_dir_all("./empty").unwrap();
+    assert!(fs::metadata("./empty").unwrap().is_dir());
+
+    remove_dir_all("./empty").unwrap();
+    assert_not_found!("./empty");
+}
+
+#[test]
+fn removes_files() {
+    fs::create_dir_all("./files").unwrap();
+
+    for i in 0..5 {
+        let path = format!("./files/empty-{}.txt", i);
+
+        {
+            let mut _file = File::create(&path);
+        }
+
+        assert!(fs::metadata(&path).unwrap().is_file());
+    }
+
+    remove_dir_all("./files").unwrap();
+    assert_not_found!("./files");
+}
+
+#[test]
+fn removes_dirs() {
+    for i in 0..5 {
+        let path = format!("./dirs/{}/subdir", i);
+
+        fs::create_dir_all(&path).unwrap();
+
+        assert!(fs::metadata(&path).unwrap().is_dir());
+    }
+
+    remove_dir_all("./dirs").unwrap();
+    assert_not_found!("./dirs");
+}
+
+#[test]
+fn removes_read_only() {
+    for i in 0..5 {
+        let path = format!("./readonly/{}/subdir", i);
+
+        fs::create_dir_all(&path).unwrap();
+
+        let file_path = format!("{}/file.txt", path);
+        {
+            let file = File::create(&file_path).unwrap();
+
+            if i % 2 == 0 {
+                let metadata = file.metadata().unwrap();
+                let mut permissions = metadata.permissions();
+                permissions.set_readonly(true);
+
+                fs::set_permissions(&file_path, permissions).unwrap();
+            }
+        }
+
+        assert_eq!(i % 2 == 0, fs::metadata(&file_path).unwrap().permissions().readonly());
+
+        if i % 2 == 1 {
+            let metadata = fs::metadata(&path).unwrap();
+
+            let mut permissions = metadata.permissions();
+            permissions.set_readonly(true);
+
+            fs::set_permissions(&path, permissions).unwrap();
+
+            assert!(fs::metadata(&path).unwrap().permissions().readonly());
+        }
+    }
+
+    remove_dir_all("./readonly").unwrap();
+    assert_not_found!("./readonly");
+}
+
+// TODO: Should probably test readonly hard links...


### PR DESCRIPTION
I was trying to use this library to delete some .git folders, which was failing due to read-only files, I just made it so that the the readonly permissions are removed and otherwise follow the same path that the non-readonly items were using since that was opening the file with the correct permissions.

I also added some simple tests to verify that it was not working before my change, and working correctly afterwards. The resetting of readonly permissions in the case of a hardlink is currently "best effort", but I have no idea if it works in a real situation.

Also spruced up the README a bit because I like badges, but I can revert that change if you don't like it. 🙂 